### PR TITLE
Update the pipeline deployment

### DIFF
--- a/kubernetes/deployments/pipeline.yaml
+++ b/kubernetes/deployments/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
         app: pipeline
     spec:
       containers:
-      - image: gcr.io/turnkey-chimera-222516/pipeline:1.0.0
+      - image: gcr.io/turnkey-chimera-222516/pipeline:1.1
         name: pipeline
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the pipeline deployment container image to:

    gcr.io/turnkey-chimera-222516/pipeline:1.1

Build ID: 872b1347-9fb2-4512-ae17-6c43574490aa